### PR TITLE
Made the Dire Dirt language pack override en_US

### DIFF
--- a/assets/minecraft/lang/en_dd.json
+++ b/assets/minecraft/lang/en_dd.json
@@ -1,7 +1,7 @@
 {
   "language.name": ".o0 Dire Dirt 0o.",
   "language.region": "A Distant Land",
-  "language.code": "en_dd",
+  "language.code": "en_us",
   "narrator.button.accessibility": "Accessibility",
   "narrator.button.language": "Language",
   "narrator.button.difficulty_lock": "Difficulty lock",


### PR DESCRIPTION
I thought it was annoying to have to select the Dire Dirt language pack to get the custom names so I made that language pack override the English (US) language pack.